### PR TITLE
Add aircraft router with bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cf-automation-airline-api
 
 ## Descripción
-Este proyecto es una API de demostración construida con **FastAPI** que simula la gestión de una aerolínea. Permite registrar usuarios, administrar vuelos, realizar reservas y pagos. La información se almacena en memoria, por lo que es ideal para fines educativos o pruebas locales.
+Este proyecto es una API de demostración construida con **FastAPI** que simula la gestión de una aerolínea. Permite registrar usuarios, administrar vuelos, manejar aeronaves, realizar reservas y pagos. La información se almacena en memoria, por lo que es ideal para fines educativos o pruebas locales.
 
 Se incluye un usuario administrador predefinido:
 
@@ -57,7 +57,7 @@ curl http://localhost:8000/bookings \
   -H "Authorization: Bearer <access_token>"
 ```
 
-Consulta `/docs` para ver todos los endpoints disponibles, incluyendo la creación de vuelos, aeropuertos, reservas y pagos.
+Consulta `/docs` para ver todos los endpoints disponibles, incluyendo la creación de vuelos, aeropuertos, aeronaves, reservas y pagos.
 
 ## Contribuciones
 Este proyecto es solo para demostración. Cualquier mejora o corrección es bienvenida mediante pull requests.

--- a/main.py
+++ b/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from routers import auth, users, airports, flights, bookings, payments
+from routers import auth, users, airports, flights, bookings, payments, aircrafts
 import models, deps
 
 app = FastAPI(
@@ -30,6 +30,7 @@ app.include_router(airports.router)
 app.include_router(flights.router)
 app.include_router(bookings.router)
 app.include_router(payments.router)
+app.include_router(aircrafts.router)
 
 @app.get("/")
 def root():

--- a/models.py
+++ b/models.py
@@ -21,6 +21,7 @@ DB: Dict[str, Dict[str, Dict]] = {
     "users": {},
     "airports": {},
     "flights": {},
+    "aircrafts": {},
     "bookings": {},
     "payments": {},
 }

--- a/routers/aircrafts.py
+++ b/routers/aircrafts.py
@@ -1,0 +1,36 @@
+from fastapi import APIRouter, Depends, HTTPException
+import models, schemas, deps
+
+router = APIRouter(prefix="/aircrafts", tags=["Aircrafts"])
+
+@router.post("", response_model=schemas.AircraftOut, status_code=201)
+def create_aircraft(ac: schemas.AircraftCreate, _: dict = Depends(deps.require_admin)):
+    aid = models.generate_id("acf")
+    data = ac.dict()
+    data["id"] = aid
+    models.DB["aircrafts"][aid] = data
+    return data
+
+@router.get("", response_model=list[schemas.AircraftOut])
+def list_aircrafts(p: dict = Depends(deps.pagination)):
+    aircrafts = models.DB["aircrafts"]  # BUG: returns dict and ignores pagination
+    return aircrafts
+
+@router.get("/{aircraft_id}", response_model=schemas.AircraftOut)
+def get_aircraft(aircraft_id: str):
+    ac = models.DB["aircrafts"].get(aircraft_id)
+    if not ac:
+        raise HTTPException(status_code=404)
+    return ac
+
+@router.put("/{aircraft_id}", response_model=schemas.AircraftOut)
+def update_aircraft(aircraft_id: str, patch: schemas.AircraftCreate, _: dict = Depends(deps.require_admin)):
+    ac = models.DB["aircrafts"].get(aircraft_id)
+    if not ac:
+        raise HTTPException(status_code=404)
+    ac.update(patch.dict())  # BUG: may overwrite with nulls
+    return ac
+
+@router.delete("/{aircraft_id}", status_code=204)
+def delete_aircraft(aircraft_id: str, _: dict = Depends(deps.require_admin)):
+    models.DB["aircrafts"].pop(aircraft_id, None)

--- a/schemas.py
+++ b/schemas.py
@@ -74,3 +74,12 @@ class PaymentOut(BaseModel):
     id: str
     booking_id: str
     status: PaymentStatus
+
+# ---------- AIRCRAFTS ----------
+class AircraftCreate(BaseModel):
+    tail_number: str = Field(min_length=5, max_length=10)
+    model: str
+    capacity: int
+
+class AircraftOut(AircraftCreate):
+    id: str


### PR DESCRIPTION
## Summary
- document support for aircrafts in README
- maintain a dedicated aircrafts collection in the in-memory DB
- define `AircraftCreate` and `AircraftOut` schemas
- expose `/aircrafts` endpoints (some intentionally buggy)
- register aircraft router in the FastAPI app

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b0b2b27cc833196de92367d811dd0