### PR TITLE
Add random seat assignment to seeded bookings

### DIFF
--- a/seed.py
+++ b/seed.py
@@ -90,7 +90,7 @@ def seed_bookings(n=7000):
                 {
                     "full_name": faker.name(),
                     "passport": faker.bothify(text="????????"),
-                    "seat": None,
+                    "seat": f"{random.randint(1, 45)}{random.choice('ABCDEF')}",
                 }
             ],
         }


### PR DESCRIPTION
## Summary
- generate a random seat identifier when seeding bookings

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687091dda7dc83319bde4e7748c96da6